### PR TITLE
fix to integer overflow

### DIFF
--- a/02-compiling/pyximport/fib.pyx
+++ b/02-compiling/pyximport/fib.pyx
@@ -7,7 +7,7 @@ def cfib(unsigned long int n):
 
 def fib(long n):
     '''Returns the nth Fibonacci number.'''
-    cdef long a=0, b=1, i
+    cdef long long a=0, b=1, i
     for i in range(n):
         a, b = a + b, a
     return a


### PR DESCRIPTION
The example code uses `print(fib(90))` and was returning `-1581614984`
